### PR TITLE
extending teardown 

### DIFF
--- a/cloudshell-orch-core/cloudshell/workflow/orchestration/teardown/default_teardown_orchestrator.py
+++ b/cloudshell-orch-core/cloudshell/workflow/orchestration/teardown/default_teardown_orchestrator.py
@@ -12,7 +12,7 @@ class DefaultTeardownWorkflow(object):
         :return:
         """
         sandbox.logger.info("Adding default teardown orchestration")
-        sandbox.workflow.set_teardown(self.default_teardown, None)
+        sandbox.workflow.add_to_teardown(self.default_teardown, None)
 
     def default_teardown(self, sandbox, components):
         """

--- a/cloudshell-orch-core/cloudshell/workflow/orchestration/workflow.py
+++ b/cloudshell-orch-core/cloudshell/workflow/orchestration/workflow.py
@@ -16,6 +16,8 @@ class Workflow(object):
     ON_CONNECTIVITY_ENDED_STAGE_NAME = 'On connectivity ended'
     CONFIGURATION_STAGE_NAME = 'Configuration'
     ON_CONFIGURATION_ENDED_STAGE_NAME = 'On configuration ended'
+    TEARDOWN_STAGE_NAME = 'Teardown'
+    BEFORE_TEARDOWN_STAGE_NAME = 'Before Teardown Started'
 
     def __init__(self, sandbox):
         self._preparation_functions = []
@@ -36,8 +38,10 @@ class Workflow(object):
         self._after_configuration = []
         """:type : list[WorkflowObject]"""
 
-        self._teardown = None
-        """:type : WorkflowObject"""
+        self._teardown_functions = []
+        """:type : list[WorkflowObject]"""
+        self._before_teardown = []
+        """:type : list[WorkflowObject]"""
 
         self.sandbox = sandbox
 
@@ -73,9 +77,13 @@ class Workflow(object):
         self._validate_function(function)
         self._after_configuration.append(WorkflowObject(function=function, components=components))
 
-    def set_teardown(self, function, components=None):
+    def add_to_teardown(self, function, components=None):
         self._validate_function(function)
-        self._teardown = WorkflowObject(function=function, components=components)
+        self._teardown_functions.append(WorkflowObject(function=function, components=components))
+
+    def before_teardown_started(self, function, components=None):
+        self._validate_function(function)
+        self._before_teardown.append(WorkflowObject(function=function, components=components))
 
     def _validate_function(self, func):
         args = inspect.getargspec(func).args


### PR DESCRIPTION
extending so it can add multiple functions to the flow with a "before teardown" stage as well. also sandbox name is added as property. the package was altered to adjust the new teadown method - default_orchastrator was changed to be with the new teardown setter (add_to_teardown).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/cloudshell-orch-sandbox/68)
<!-- Reviewable:end -->
