### PR TITLE
Fix syntax anomaly

### DIFF
--- a/cloudshell-orch-core/cloudshell/workflow/orchestration/components.py
+++ b/cloudshell-orch-core/cloudshell/workflow/orchestration/components.py
@@ -4,7 +4,7 @@ from cloudshell.workflow.orchestration.app import App
 
 class Components(object):
     def __init__(self, resources, services, apps):
-        self.apps = dict((app.Name, App(app)) for app in apps if len(app.DeploymentPaths) > 0)  # avoid bug in
+        self.apps = {app.Name : App(app)) for app in apps if len(app.DeploymentPaths) > 0}  # avoid bug in
         # cloudshell-automation-api where an app named None returns even when there are no apps in the reservation
         """:type : dict[str, App]"""
         self.resources = {}


### PR DESCRIPTION
Dictionary comprehension should be used when populating a dictionary (in the form of {item.key:item.value for item in collection} ) instead of the currently used generator comprehension with tuples which is then converted to a dictionary. 

this reduces casting and cleans up the syntax.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/cloudshell-orch-sandbox/69)
<!-- Reviewable:end -->
