### PR TITLE
fixed bug - refresh vm details should happen if "Wait for IP" attribu…

### DIFF
--- a/cloudshell-orch-core/cloudshell/workflow/orchestration/setup/default_setup_orchestrator.py
+++ b/cloudshell-orch-core/cloudshell/workflow/orchestration/setup/default_setup_orchestrator.py
@@ -46,7 +46,6 @@ class DefaultSetupWorkflow(object):
 
         sandbox.components.refresh_components(sandbox=sandbox)
 
-
         DefaultSetupLogic.try_exeucte_autoload(api=api,
                                                deploy_result=self._deploy_result,
                                                resource_details_cache=self._resource_details_cache,
@@ -82,7 +81,8 @@ class DefaultSetupWorkflow(object):
                                              reservation_details=reservation_details,
                                              connect_results=connect_results,
                                              resource_details_cache=self._resource_details_cache,
-                                             logger=sandbox.logger)
+                                             logger=sandbox.logger,
+                                             components=sandbox.components)
 
     def default_configuration(self, sandbox, components):
         """


### PR DESCRIPTION
…te is true. This method lacked support for 2nd gen shell attributes and also search for 'wait for ip' in custom params. Bug fixed by adding support for 2nd gen shell attribute and searching for the "Wait for IP" attribute on the deployment service.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/cloudshell-orch-sandbox/123)
<!-- Reviewable:end -->
